### PR TITLE
Allow for usage of latest rest-client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
-before_install: gem install bundler -v 1.11.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
 before_install: gem install bundler -v 1.11.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## 1.0.1
+
+### Added
+
+- `Kami::Document` now has a `download` method
+- This CHANGELOG :)
+
+## 1.0.0
+
+Initial Release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Kami::Document` now has a `download` method
 - This CHANGELOG :)
 
+### Changed
+
+- Loosen up gemspec version requirements to allow for `rest-client` 2.x
+
 ## 1.0.0
 
 Initial Release.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ API Documentation: http://docs.kamiembeddingapi.apiary.io/
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'kami', github: 'jheth/kami'
+gem 'kami'
 ```
 
 And then execute:

--- a/kami.gemspec
+++ b/kami.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rest-client", ">= 1.8.0", "< 1.9.0"
+  spec.add_runtime_dependency "rest-client", ">= 1.8.0", "< 3.0"
 
   spec.add_development_dependency "bundler", ">= 1.11", "< 2.0"
   spec.add_development_dependency "rake", ">= 10.0", "< 12.0"


### PR DESCRIPTION
I ran into an issue when running `bundle outdated` on a project where `rest-client` 2.x was required by another gem. This change updates the gemspec so that the latest version can be used.

I also cleaned up a bit and added a CHANGELOG.

Do you have an API key that can be used to re-record the VCR cassettes with the latest `rest-client`?